### PR TITLE
Hide tooltips on mobile devices

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -193,6 +193,7 @@ svg {
 }
 
 .tooltip {
+  display: none;
   position: absolute;
   top: 50%;
   left: calc(100% + 1em);
@@ -623,6 +624,10 @@ svg {
 }
 
 @media (hover: hover) {
+  .tooltip {
+    display: block;
+  }
+
   .btn:hover .tooltip,
   .input-container:hover .tooltip {
     opacity: 1;


### PR DESCRIPTION
### Cambios
Se esconden los tooltips en mobile, para que no generen bugs visuales al tapear botones.