### PR TITLE
Update Canvas drawing logic

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 110
 }

--- a/scripts/canvas.ts
+++ b/scripts/canvas.ts
@@ -1,4 +1,9 @@
-import type { CanvasEvent, DrawingMode } from './types/types';
+import type {
+  CanvasEvent,
+  ContextObject,
+  Coordinate,
+  DrawingMode,
+} from './types/index';
 import { $, isTouchEvent } from './utils';
 
 export class Canvas {
@@ -6,28 +11,45 @@ export class Canvas {
   private context: CanvasRenderingContext2D;
   private pointer: HTMLElement;
   private isDrawing: boolean;
-  private coordinates: Record<'x' | 'y', number>;
-  private radius: number;
-  private drawingEventFunction: ((e: CanvasEvent) => void) | null;
+  private coordinates: Array<Coordinate>;
+  private size: number;
+  private isTouch: boolean;
+  private currentCoords: Coordinate;
+  private memoryCanvas: HTMLCanvasElement;
+  private listeners: Record<string, (() => void) | null>;
+  memoryContext: CanvasRenderingContext2D;
   width: number;
   height: number;
   color: string;
+  hue: number;
   backgroundColor: string;
   drawingMode: DrawingMode;
 
   constructor(selector: string) {
     this.canvas = $<HTMLCanvasElement>(selector);
     this.context = this.canvas.getContext('2d', { willReadFrequently: true })!;
+    this.listeners = {
+      mouseLeave: null,
+      drawingListener: null,
+    };
+
+    this.memoryCanvas = document.createElement('canvas');
+    this.memoryContext = this.memoryCanvas.getContext('2d', {
+      willReadFrequently: true,
+    })!;
+
     this.pointer = $('#pointer');
     this.width = window.innerWidth;
     this.height = window.innerHeight;
+    this.hue = 15;
     this.color = '#000';
     this.backgroundColor = 'white';
     this.drawingMode = 'brush';
     this.isDrawing = false;
-    this.radius = 5;
-    this.coordinates = { x: 0, y: 0 };
-    this.drawingEventFunction = null;
+    this.size = 5;
+    this.currentCoords = { x: 0, y: 0 };
+    this.coordinates = [];
+    this.isTouch = false;
 
     this.setupCanvas();
   }
@@ -35,22 +57,50 @@ export class Canvas {
   private setupCanvas() {
     this.canvas.width = this.width;
     this.canvas.height = this.height;
+    this.memoryCanvas.width = this.width;
+    this.memoryCanvas.height = this.height;
+    this.context.lineCap = 'round';
+    this.context.lineJoin = 'round';
 
     window.addEventListener('mousemove', ({ x, y }) => {
-      this.coordinates.x = x;
-      this.coordinates.y = y;
+      const coords: Coordinate = { x, y };
+
+      if (this.drawingMode === 'rainbow-brush') {
+        coords.hue = this.hue++;
+      }
+      this.currentCoords = coords;
+      this.pointer.style.top = y + 'px';
+      this.pointer.style.left = x + 'px';
+    });
+
+    window.addEventListener('touchmove', ({ touches }) => {
+      const { clientX: x, clientY: y } = touches[0];
+      const coords: Coordinate = { x, y };
+
+      if (this.drawingMode === 'rainbow-brush') {
+        coords.hue = this.hue++;
+      }
+
+      this.currentCoords = coords;
       this.pointer.style.top = y + 'px';
       this.pointer.style.left = x + 'px';
     });
 
     window.addEventListener('resize', () => {
-      this.canvas.width = window.innerWidth;
-      this.canvas.height = window.innerHeight;
+      this.resize(window.innerWidth, window.innerHeight);
+    });
+
+    window.addEventListener('mouseleave', () => {
+      console.log('mouseleave');
+      this.stopDrawing();
     });
   }
 
-  getContext() {
-    return this.context;
+  getContext(): ContextObject {
+    return {
+      main: this.context,
+      memory: this.memoryContext,
+    };
   }
 
   getCanvasElement() {
@@ -68,12 +118,16 @@ export class Canvas {
   fill(color: string = this.color) {
     this.context.fillStyle = color;
     this.context.fillRect(0, 0, this.width, this.height);
+    this.memoryContext.fillStyle = color;
+    this.memoryContext.fillRect(0, 0, this.width, this.height);
     this.backgroundColor = color;
   }
 
   resize(width: number, height: number) {
     this.canvas.width = width;
     this.canvas.height = height;
+    this.memoryCanvas.width = width;
+    this.memoryCanvas.height = height;
     this.width = width;
     this.height = height;
   }
@@ -82,56 +136,116 @@ export class Canvas {
     this.drawingMode = mode;
   }
 
-  changeRadius(radius: number) {
-    this.radius = radius;
-    this.pointer.style.width = radius + 'px';
-    this.pointer.style.height = radius + 'px';
+  changeSize(size: number) {
+    this.size = size;
+    this.pointer.style.width = size + 'px';
+    this.pointer.style.height = size + 'px';
   }
 
   beginDrawing(ev: CanvasEvent) {
     this.isDrawing = true;
-    this.drawingEventFunction = (e: CanvasEvent) => this.draw(e);
-    this.canvas.addEventListener('mousemove', this.drawingEventFunction);
-    this.canvas.addEventListener('touchmove', this.drawingEventFunction);
-    this.reposition(ev);
+    this.isTouch = isTouchEvent(ev);
+
+    this.listeners.drawingListener = () => {
+      this.context.clearRect(0, 0, this.width, this.height);
+      this.context.drawImage(this.memoryCanvas, 0, 0);
+      this.coordinates.push(this.currentCoords);
+      this.draw();
+    };
+
+    this.canvas.addEventListener('mousemove', this.listeners.drawingListener);
+    this.canvas.addEventListener('touchmove', this.listeners.drawingListener);
   }
 
   stopDrawing() {
     this.isDrawing = false;
+    this.coordinates = [];
+    this.memoryContext.clearRect(0, 0, this.width, this.height);
+    this.memoryContext.drawImage(this.canvas, 0, 0);
+    const drawingListener = this.listeners.drawingListener;
 
-    if (this.drawingEventFunction) {
-      this.canvas.removeEventListener('mousemove', this.drawingEventFunction);
-      this.canvas.removeEventListener('touchmove', this.drawingEventFunction);
-      this.drawingEventFunction = null;
+    if (drawingListener) {
+      this.canvas.removeEventListener('mousemove', drawingListener);
+      this.canvas.removeEventListener('touchmove', drawingListener);
+      this.listeners.drawingListener = null;
     }
   }
 
-  draw(ev: CanvasEvent) {
-    if (!this.isDrawing) {
+  private getDrawingColor(hue?: number) {
+    return hue && this.drawingMode === 'rainbow-brush'
+      ? `hsl(${hue}, 80%, 70%)`
+      : this.color;
+  }
+
+  draw() {
+    if (!this.isDrawing || !this.coordinates.length) {
       return;
     }
 
+    const length = this.coordinates.length;
+    const initialCoord = this.coordinates[0];
+
+    if (length < 3) {
+      this.context.strokeStyle = this.getDrawingColor(initialCoord.hue);
+      this.context.fillStyle = this.getDrawingColor(initialCoord.hue);
+
+      this.context.beginPath();
+      this.context.arc(
+        initialCoord.x,
+        initialCoord.y,
+        this.size / 2,
+        0,
+        Math.PI * 2,
+      );
+      this.context.closePath();
+      this.context.fill();
+
+      this.memoryContext.clearRect(0, 0, this.width, this.height);
+      this.memoryContext.drawImage(this.canvas, 0, 0);
+      return;
+    }
+
+    this.context.lineWidth = this.size;
     this.context.beginPath();
-    this.context.lineWidth = this.radius;
-    this.context.lineCap = 'round';
-    this.context.lineJoin = 'round';
-    this.context.strokeStyle = this.color;
-    this.context.moveTo(this.coordinates.x, this.coordinates.y);
-    this.reposition(ev);
-    this.context.lineTo(this.coordinates.x, this.coordinates.y);
+    this.context.moveTo(initialCoord.x, initialCoord.y);
+
+    for (let i = 1; i < length - 1; i++) {
+      const currentCoord = this.coordinates[i];
+      const nextCoord = this.coordinates[i + 1];
+      const avgX = (currentCoord.x + nextCoord.x) / 2;
+      const avgY = (currentCoord.y + nextCoord.y) / 2;
+
+      this.context.strokeStyle = this.getDrawingColor(currentCoord.hue);
+      this.context.quadraticCurveTo(currentCoord.x, currentCoord.y, avgX, avgY);
+      this.context.stroke();
+      this.context.beginPath();
+      this.context.moveTo(avgX, avgY);
+    }
+
+    const [secondToLastCoord, lastCoord] = this.coordinates.slice(-2);
+
+    this.context.strokeStyle = this.getDrawingColor(secondToLastCoord.hue);
+    this.context.quadraticCurveTo(
+      secondToLastCoord.x,
+      secondToLastCoord.y,
+      lastCoord.x,
+      lastCoord.y,
+    );
     this.context.stroke();
   }
 
-  reposition(ev: CanvasEvent) {
-    if (ev.target === this.canvas) {
-      ev.preventDefault();
+  getMouseCoordinates(ev: CanvasEvent) {
+    if (this.isTouch) {
+      return {
+        x: (ev as TouchEvent).touches[0].clientX,
+        y: (ev as TouchEvent).touches[0].clientY,
+      };
     }
 
-    const xCoord = isTouchEvent(ev) ? ev.touches[0].clientX : ev.clientX;
-    const yCoord = isTouchEvent(ev) ? ev.touches[0].clientY : ev.clientY;
-
-    this.coordinates.x = xCoord - this.canvas.offsetLeft;
-    this.coordinates.y = yCoord - this.canvas.offsetTop;
+    return {
+      x: (ev as MouseEvent).clientX,
+      y: (ev as MouseEvent).clientY,
+    };
   }
 
   getCanvasAsImage() {
@@ -141,11 +255,6 @@ export class Canvas {
   onBeginDrawing(cb: (ev: CanvasEvent) => void) {
     this.canvas.addEventListener('mousedown', cb);
     this.canvas.addEventListener('touchstart', cb);
-  }
-
-  onDraw(cb: (ev: CanvasEvent) => void) {
-    this.canvas.addEventListener('mousemove', cb);
-    this.canvas.addEventListener('touchmove', cb);
   }
 
   onStopDrawing(cb: (ev: CanvasEvent) => void) {

--- a/scripts/history.ts
+++ b/scripts/history.ts
@@ -1,3 +1,5 @@
+import { ContextObject } from './types/index';
+
 type CanvasState = {
   canvasContext: {
     backgroundColor: string;
@@ -7,12 +9,12 @@ type CanvasState = {
 
 export class Snapshot {
   private history: Array<CanvasState>;
-  private context: CanvasRenderingContext2D;
+  private context: ContextObject;
   private width: number;
   private height: number;
   private initialSnapshot: ImageData | null;
 
-  constructor(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  constructor(ctx: ContextObject, width: number, height: number) {
     this.context = ctx;
     this.history = [];
     this.width = width;
@@ -22,7 +24,7 @@ export class Snapshot {
   }
 
   private addInitialSnapshot = () => {
-    const initialSnapshot = this.context.getImageData(
+    const initialSnapshot = this.context.main.getImageData(
       0,
       0,
       this.width,
@@ -41,7 +43,7 @@ export class Snapshot {
   addSnapshot = (bgColor: string) => {
     this.history.push({
       canvasContext: { backgroundColor: bgColor },
-      snapshot: this.context.getImageData(0, 0, this.width, this.height),
+      snapshot: this.context.main.getImageData(0, 0, this.width, this.height),
     });
   };
 
@@ -55,7 +57,8 @@ export class Snapshot {
     if (this.history.length > 1) {
       this.history.pop()!;
       const previousState = this.history[this.history.length - 1];
-      this.context.putImageData(previousState.snapshot, 0, 0);
+      this.context.main.putImageData(previousState.snapshot, 0, 0);
+      this.context.memory.putImageData(previousState.snapshot, 0, 0);
 
       return {
         canvasContext: previousState.canvasContext,

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -1,4 +1,4 @@
-import type { CanvasEvent } from './types/types.js';
+import type { CanvasEvent } from './types/index.js';
 import { Snapshot } from './history.js';
 import { $, $$, getRandomColor } from './utils.js';
 import { Canvas } from './canvas.js';
@@ -36,8 +36,6 @@ const notificationsContainer = new NotificationContainer(
   $('#notifications-container'),
 );
 
-let hue = 15; // para el input rainbow
-let rainbowColor = `hsl(${hue}, 80%, 70%)`;
 let isDialogOpen = false;
 const collapseButtonHeight = `${btnCollapseToolbar.scrollHeight}px`;
 const toolbarHeight = `${toolbar.scrollHeight}px`;
@@ -63,22 +61,6 @@ const undoAndSetCanvasColor = () => {
   }
 };
 
-const draw = (ev: CanvasEvent) => {
-  const { drawingMode } = canvas;
-
-  canvas.draw(ev);
-
-  if (drawingMode === 'rainbow-brush') {
-    hue += 1;
-    rainbowColor = `hsl(${hue}, 80%, 70%)`;
-    canvas.setColor(rainbowColor);
-  }
-};
-
-const beginDrawing = (ev: CanvasEvent) => {
-  canvas.beginDrawing(ev);
-};
-
 const stopDrawing = () => {
   canvas.stopDrawing();
   addSnapshot(canvas.backgroundColor);
@@ -88,12 +70,11 @@ const fillCanvasOrBeginDrawing = (ev: CanvasEvent) => {
   if (current === btnRoller) {
     canvas.fill();
   } else {
-    beginDrawing(ev);
+    canvas.beginDrawing(ev);
   }
 };
 
 canvas.onBeginDrawing(fillCanvasOrBeginDrawing);
-canvas.onDraw(draw);
 canvas.onStopDrawing(stopDrawing);
 
 let current = btnBrush; // nuestra herramienta activa
@@ -148,7 +129,6 @@ btnEraser.addEventListener('click', selectEraserTool);
 const selectRainbowTool = () => {
   updateCurrent(btnRainbow);
   canvas.changeDrawingMode('rainbow-brush');
-  canvas.setColor(rainbowColor);
 };
 btnRainbow.addEventListener('click', selectRainbowTool);
 
@@ -187,9 +167,9 @@ inputColor.addEventListener('change', () => {
 
 // Tamaño pincel
 inputRange.addEventListener('input', () => {
-  const radius = Number(inputRange.value);
-  canvas.changeRadius(radius);
-  brushSize.innerText = `${radius} px`;
+  const size = Number(inputRange.value);
+  canvas.changeSize(size);
+  brushSize.innerText = `${size} px`;
 });
 
 confirmTopTrap.addEventListener('focus', () => cancelClearBoardButton.focus());
@@ -332,8 +312,12 @@ const keyMaps = {
 
 type KeyMapKeys = keyof typeof keyMaps;
 
+let isClickPressed = false;
+
+window.addEventListener('mousedown', () => (isClickPressed = true));
+window.addEventListener('mouseup', () => (isClickPressed = false));
 window.addEventListener('keydown', (ev) => {
-  if (isDialogOpen) {
+  if (isDialogOpen || isClickPressed) {
     return;
   }
 

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -1,0 +1,11 @@
+export type CanvasEvent = MouseEvent | TouchEvent;
+export type DrawingMode = 'brush' | 'rainbow-brush' | 'eraser';
+export type Coordinate = {
+  x: number;
+  y: number;
+  hue?: number;
+};
+export type ContextObject = {
+  main: CanvasRenderingContext2D;
+  memory: CanvasRenderingContext2D;
+};

--- a/scripts/types/types.ts
+++ b/scripts/types/types.ts
@@ -1,2 +1,0 @@
-export type CanvasEvent = MouseEvent | TouchEvent;
-export type DrawingMode = 'brush' | 'rainbow-brush' | 'eraser';


### PR DESCRIPTION
### Contexto
Con el fin de obtener trazos menos poligonales, se modifica la lógica de dibujado del Canvas.

| Antes| Después|
|--------|--------|
| <img src="https://github.com/user-attachments/assets/18c28a3d-10b5-46f2-b038-1af9324ff7c5">| <img src="https://github.com/user-attachments/assets/cf217ad6-e7e9-4185-9fde-ccead2762fb1">| 

### Cambios
- Se modifica la lógica del método `draw()`: en lugar de un `lineTo`, se realiza un `quadraticCurveTo` para obtener curvas más suaves entre las coordenadas
- Se guarda en memoria el último estado del Canvas utilizando `memoryCanvas`, para poder limpiar el array de coordenadas y evitar problemas de performance. Este último estado se pinta cada vez que se ejecuta `beginDrawing()`
- El cambio de `draw()` trajo el problema de que ahora todo el trazo era de un único color y el Rainbow Brush no funcionaba debidamente. Para solventar esto, ahora el color que le correspondería a cada punto se guarda en las coordenadas y se obtiene cuando se seleccionó el Rainbow Brush. Además, se modifica cuándo se ejecuta `stroke()`
- Se añade lógica en `history` para contemplar el nuevo `memoryCanvas`
- Se corrige bug donde el usuario puede seleccionar herramientas usando los atajos de teclado mientras dibuja. Ahora, mediante un flag `isClickPressed` se deshabilitan todos los atajos de teclado
- Se renombra `types.ts` a `index.ts` y se llevan ahí types relacionados
- Se elimina método `onDraw()` innecesario del Canvas