### PR TITLE
Fill canvas on setup

### DIFF
--- a/scripts/canvas.ts
+++ b/scripts/canvas.ts
@@ -57,6 +57,8 @@ export class Canvas {
     this.context.lineCap = 'round';
     this.context.lineJoin = 'round';
 
+    this.fill(this.backgroundColor);
+
     window.addEventListener('mousemove', ({ x, y }) => {
       const coords: Coordinate = { x, y };
 


### PR DESCRIPTION
### Cambios
Se rellena el canvas de blanco al inicio para que el dibujo no se descargue con fondo transparente.