### PR TITLE
Move ConfirmDialog logic to its own file

### DIFF
--- a/scripts/confirm-dialog.ts
+++ b/scripts/confirm-dialog.ts
@@ -1,0 +1,87 @@
+import { $ } from './utils';
+
+const toolbar = $('#toolbar');
+const overlay = $('#confirm-overlay');
+const dialog = $('#confirm');
+const [confirmButton, cancelButton] = dialog.querySelectorAll('button');
+const [confirmTopTrap, confirmBottomTrap] = dialog.querySelectorAll('[id^=confirm-focus-trap]');
+const btnClear = $('#btn-clear');
+
+export class ConfirmDialog {
+  private onConfirm: () => void;
+  private onCancel: () => void;
+  private listeners: {
+    confirmAction: (ev: MouseEvent) => void;
+    hideOnClick: (ev: MouseEvent) => void;
+    hideOnEsc: (ev: KeyboardEvent) => void;
+    manageFocus: (ev: Event) => void;
+  };
+
+  constructor(onConfirm: () => void, onCancel: () => void) {
+    this.onConfirm = onConfirm;
+    this.onCancel = onCancel;
+    this.listeners = {
+      confirmAction: () => {
+        this.onConfirm();
+        this.hide();
+      },
+      hideOnClick: (ev: MouseEvent) => {
+        if (ev.target === overlay || ev.target === cancelButton) {
+          this.hide();
+          this.onCancel();
+        }
+      },
+      hideOnEsc: (ev: KeyboardEvent) => {
+        if (ev.key === 'Escape') {
+          this.hide();
+          this.onCancel();
+        }
+      },
+      manageFocus: (ev: Event) => {
+        if (ev.target === confirmTopTrap) {
+          cancelButton.focus();
+        } else if (ev.target === confirmBottomTrap) {
+          confirmButton.focus();
+        }
+      },
+    };
+  }
+
+  show() {
+    toolbar.setAttribute('inert', 'true');
+    overlay.classList.add('visible');
+    dialog.classList.add('visible');
+    confirmButton.focus();
+
+    confirmTopTrap.addEventListener('focus', this.listeners.manageFocus);
+    confirmBottomTrap.addEventListener('focus', this.listeners.manageFocus);
+    overlay.addEventListener('keydown', this.listeners.hideOnEsc);
+    confirmButton.addEventListener('click', this.listeners.confirmAction);
+    cancelButton.addEventListener('click', this.listeners.hideOnClick);
+    overlay.addEventListener('click', this.listeners.hideOnClick);
+  }
+
+  hide() {
+    toolbar.removeAttribute('inert');
+    overlay.classList.add('hiding');
+    dialog.classList.remove('visible');
+
+    overlay.addEventListener(
+      'animationend',
+      () => {
+        overlay.classList.remove('visible', 'hiding');
+      },
+      { once: true },
+    );
+
+    confirmTopTrap.removeEventListener('focus', this.listeners.manageFocus);
+    confirmBottomTrap.removeEventListener('focus', this.listeners.manageFocus);
+    overlay.removeEventListener('keydown', this.listeners.hideOnEsc);
+    confirmButton.removeEventListener('click', this.listeners.confirmAction);
+    cancelButton.removeEventListener('click', this.listeners.hideOnClick);
+    overlay.removeEventListener('click', this.listeners.hideOnClick);
+
+    // Restore focus to the button that opened the confirm dialog
+    btnClear.focus();
+  }
+}

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -3,6 +3,7 @@ import { Snapshot } from './history.js';
 import { $, $$, getRandomColor } from './utils.js';
 import { Canvas } from './canvas.js';
 import { NotificationContainer } from './notification.js';
+import { ConfirmDialog } from './confirm-dialog.js';
 
 const root = $(':root');
 
@@ -20,10 +21,6 @@ const btnRandom = $('#btn-random');
 const btnClear = $('#btn-clear');
 const [inputColor, inputRange] = $$<HTMLInputElement>('input');
 const brushSize = $('.brush-size');
-const confirmOverlay = $('#confirm-overlay');
-const confirmDialog = $('#confirm');
-const [clearBoardButton, cancelClearBoardButton] = confirmDialog.querySelectorAll('button');
-const [confirmTopTrap, confirmBottomTrap] = confirmDialog.querySelectorAll('[id^=confirm-focus-trap]');
 const btnInfo = $('#btn-info');
 const btnClose = $('#btn-close');
 const overlay = $('#modal-overlay');
@@ -181,47 +178,24 @@ inputRange.addEventListener('input', () => {
   brushSize.innerText = `${size} px`;
 });
 
-confirmTopTrap.addEventListener('focus', () => cancelClearBoardButton.focus());
-confirmBottomTrap.addEventListener('focus', () => clearBoardButton.focus());
-
 const showConfirmDialog = () => {
   isDialogOpen = true;
-  toolbar.setAttribute('inert', 'true');
-  confirmOverlay.classList.add('visible');
-  confirmDialog.classList.add('visible');
-  clearBoardButton.focus();
-  confirmOverlay.addEventListener('keydown', hideConfirmDialogOnEsc);
+  confirmDialog.show();
 };
 
-const hideConfirmDialog = () => {
-  isDialogOpen = false;
-  toolbar.removeAttribute('inert');
-  confirmOverlay.classList.remove('visible');
-  confirmDialog.classList.remove('visible');
-
-  // Restore focus to the button that opened the confirm dialog
-  btnClear.focus();
-  confirmOverlay.removeEventListener('keydown', hideConfirmDialogOnEsc);
-};
-
-const hideConfirmDialogOnEsc = (ev: KeyboardEvent) => {
-  if (ev.key === 'Escape') {
-    hideConfirmDialog();
-  }
-};
+const hideConfirmDialog = () => (isDialogOpen = false);
 
 const clearBoard = () => {
+  isDialogOpen = false;
   canvas.fill('white');
   if (canvas.drawingMode === 'eraser') {
     canvas.setColor(canvas.backgroundColor);
   }
-  hideConfirmDialog();
   clearHistory();
 };
 
+const confirmDialog = new ConfirmDialog(clearBoard, hideConfirmDialog);
 btnClear.addEventListener('click', showConfirmDialog);
-clearBoardButton.addEventListener('click', clearBoard);
-cancelClearBoardButton.addEventListener('click', hideConfirmDialog);
 
 /* Managing Focus Trap inside the modal */
 const [topFocusTrap, bottomFocusTrap] = modal.querySelectorAll('[id^=modal-focus-trap]');


### PR DESCRIPTION
### Cambios
Se mueve la lógica del `ConfirmDialog` a su propio archivo para mayor prolijidad del index.
Adicionalmente, se le da una animación de salida.