### PR TITLE
Pass Canvas to the History class instead of separate properties

### DIFF
--- a/scripts/canvas.ts
+++ b/scripts/canvas.ts
@@ -254,3 +254,5 @@ export class Canvas {
     this.canvas.addEventListener('touchend', cb);
   }
 }
+
+export type CanvasInstance = InstanceType<typeof Canvas>;

--- a/scripts/history.ts
+++ b/scripts/history.ts
@@ -1,3 +1,4 @@
+import type { CanvasInstance } from './canvas';
 import { ContextObject } from './types/index';
 
 type CanvasState = {
@@ -14,22 +15,17 @@ export class Snapshot {
   private height: number;
   private initialSnapshot: ImageData | null;
 
-  constructor(ctx: ContextObject, width: number, height: number) {
-    this.context = ctx;
+  constructor(canvas: CanvasInstance) {
+    this.context = canvas.getContext();
     this.history = [];
-    this.width = width;
-    this.height = height;
+    this.width = canvas.width;
+    this.height = canvas.height;
     this.initialSnapshot = null;
     this.addInitialSnapshot();
   }
 
   private addInitialSnapshot = () => {
-    const initialSnapshot = this.context.main.getImageData(
-      0,
-      0,
-      this.width,
-      this.height,
-    );
+    const initialSnapshot = this.context.main.getImageData(0, 0, this.width, this.height);
     this.history.push({
       snapshot: initialSnapshot,
       canvasContext: { backgroundColor: 'white' },

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -35,11 +35,7 @@ const collapseButtonHeight = `${btnCollapseToolbar.scrollHeight}px`;
 const toolbarHeight = `${toolbar.scrollHeight}px`;
 toolbar.style.height = toolbarHeight;
 
-const { addSnapshot, undoLastAction, clearHistory } = new Snapshot(
-  canvas.getContext(),
-  canvas.width,
-  canvas.height,
-);
+const { addSnapshot, undoLastAction, clearHistory } = new Snapshot(canvas);
 
 const undoAndSetCanvasColor = () => {
   const { canvasContext, undoSuccessful } = undoLastAction();


### PR DESCRIPTION
### Cambios
En lugar de pasarle por separado el context, ancho y alto del Canvas a la clase History, se le pasa la instancia de la clase Canvas.