### PR TITLE
Move InfoModal logic to its own file

### DIFF
--- a/scripts/confirm-dialog.ts
+++ b/scripts/confirm-dialog.ts
@@ -3,48 +3,43 @@ import { $ } from './utils';
 const toolbar = $('#toolbar');
 const overlay = $('#confirm-overlay');
 const dialog = $('#confirm');
+const btnClear = $('#btn-clear');
+
 const [confirmButton, cancelButton] = dialog.querySelectorAll('button');
 const [confirmTopTrap, confirmBottomTrap] = dialog.querySelectorAll('[id^=confirm-focus-trap]');
-const btnClear = $('#btn-clear');
 
 export class ConfirmDialog {
   private onConfirm: () => void;
   private onCancel: () => void;
-  private listeners: {
-    confirmAction: (ev: MouseEvent) => void;
-    hideOnClick: (ev: MouseEvent) => void;
-    hideOnEsc: (ev: KeyboardEvent) => void;
-    manageFocus: (ev: Event) => void;
+  private listeners = {
+    confirmAction: () => {
+      this.onConfirm();
+      this.hide();
+    },
+    hideOnClick: ({ target }: MouseEvent) => {
+      if (target === overlay || target === cancelButton) {
+        this.hide();
+        this.onCancel();
+      }
+    },
+    hideOnEsc: ({ key }: KeyboardEvent) => {
+      if (key === 'Escape') {
+        this.hide();
+        this.onCancel();
+      }
+    },
+    manageFocus: ({ target }: Event) => {
+      if (target === confirmTopTrap) {
+        cancelButton.focus();
+      } else if (target === confirmBottomTrap) {
+        confirmButton.focus();
+      }
+    },
   };
 
   constructor(onConfirm: () => void, onCancel: () => void) {
     this.onConfirm = onConfirm;
     this.onCancel = onCancel;
-    this.listeners = {
-      confirmAction: () => {
-        this.onConfirm();
-        this.hide();
-      },
-      hideOnClick: (ev: MouseEvent) => {
-        if (ev.target === overlay || ev.target === cancelButton) {
-          this.hide();
-          this.onCancel();
-        }
-      },
-      hideOnEsc: (ev: KeyboardEvent) => {
-        if (ev.key === 'Escape') {
-          this.hide();
-          this.onCancel();
-        }
-      },
-      manageFocus: (ev: Event) => {
-        if (ev.target === confirmTopTrap) {
-          cancelButton.focus();
-        } else if (ev.target === confirmBottomTrap) {
-          confirmButton.focus();
-        }
-      },
-    };
   }
 
   show() {
@@ -70,6 +65,9 @@ export class ConfirmDialog {
       'animationend',
       () => {
         overlay.classList.remove('visible', 'hiding');
+
+        // Restore focus to the button that opened the confirm dialog
+        btnClear.focus();
       },
       { once: true },
     );
@@ -80,8 +78,5 @@ export class ConfirmDialog {
     confirmButton.removeEventListener('click', this.listeners.confirmAction);
     cancelButton.removeEventListener('click', this.listeners.hideOnClick);
     overlay.removeEventListener('click', this.listeners.hideOnClick);
-
-    // Restore focus to the button that opened the confirm dialog
-    btnClear.focus();
   }
 }

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -4,6 +4,7 @@ import { $, $$, getRandomColor } from './utils.js';
 import { Canvas } from './canvas.js';
 import { NotificationContainer } from './notification.js';
 import { ConfirmDialog } from './confirm-dialog.js';
+import { InfoDialog } from './info-dialog.js';
 
 const root = $(':root');
 
@@ -23,9 +24,6 @@ const btnClear = $('#btn-clear');
 const [inputColor, inputRange] = $$<HTMLInputElement>('input');
 const brushSize = $('.brush-size');
 const btnInfo = $('#btn-info');
-const btnClose = $('#btn-close');
-const overlay = $('#modal-overlay');
-const modal = $('#modal');
 const btnDownload = $<HTMLAnchorElement>('#btn-download');
 const allButtonsInsideToolbar = toolbar.querySelectorAll<HTMLElement>('button, a, input')!;
 const notificationsContainer = new NotificationContainer($('#notifications-container'));
@@ -196,62 +194,13 @@ const clearBoard = () => {
 const confirmDialog = new ConfirmDialog(clearBoard, hideConfirmDialog);
 btnClear.addEventListener('click', showConfirmDialog);
 
-/* Managing Focus Trap inside the modal */
-const [topFocusTrap, bottomFocusTrap] = modal.querySelectorAll('[id^=modal-focus-trap]');
-const allFocusableElements = modal.querySelectorAll('button, a') as NodeListOf<HTMLElement>;
-const firstFocusableElement = allFocusableElements[0];
-const lastFocusableElement = allFocusableElements[allFocusableElements.length - 1];
-
-const goToFirstFocusableElement = () => firstFocusableElement.focus();
-const goToLastFocusableElement = () => lastFocusableElement.focus();
-
-topFocusTrap.addEventListener('focus', goToLastFocusableElement);
-bottomFocusTrap.addEventListener('focus', goToFirstFocusableElement);
-
 const openModal = () => {
   isDialogOpen = true;
-  toolbar.setAttribute('inert', 'true');
-  overlay.classList.add('visible');
-
-  window.addEventListener('keydown', closeModalOnEsc);
-
-  firstFocusableElement.focus();
+  infoDialog.show();
 };
-
-const closeModal = () => {
-  isDialogOpen = false;
-  toolbar.removeAttribute('inert');
-  overlay.classList.add('hiding');
-
-  overlay.addEventListener(
-    'animationend',
-    () => {
-      overlay.classList.remove('visible', 'hiding');
-    },
-    { once: true },
-  );
-
-  window.removeEventListener('keydown', closeModalOnEsc);
-
-  // Restore focus to the button that opened the modal
-  btnInfo.focus();
-};
-
+const closeModal = () => (isDialogOpen = false);
+const infoDialog = new InfoDialog(closeModal);
 btnInfo.addEventListener('click', openModal);
-
-btnClose.addEventListener('click', closeModal);
-
-overlay.addEventListener('click', (ev) => {
-  if (ev.target === overlay) {
-    closeModal();
-  }
-});
-
-const closeModalOnEsc = (ev: KeyboardEvent) => {
-  if (ev.key === 'Escape') {
-    closeModal();
-  }
-};
 
 //
 // ========== DESCARGAR IMAGEN ==========

--- a/scripts/info-dialog.ts
+++ b/scripts/info-dialog.ts
@@ -1,0 +1,76 @@
+import { $ } from './utils';
+
+const toolbar = $('#toolbar');
+const overlay = $('#modal-overlay');
+const dialog = $('#modal');
+const btnClose = $('#btn-close');
+const btnInfo = $('#btn-info');
+
+const [topFocusTrap, bottomFocusTrap] = dialog.querySelectorAll('[id^=modal-focus-trap]');
+const allFocusableElements = dialog.querySelectorAll<HTMLElement>('button, a');
+const firstFocusableElement = allFocusableElements[0];
+const lastFocusableElement = allFocusableElements[allFocusableElements.length - 1];
+
+export class InfoDialog {
+  private onClose: () => void;
+  private listeners = {
+    hideOnClick: ({ target }: MouseEvent) => {
+      const isNode = target instanceof Node;
+      if (isNode && (target === overlay || btnClose.contains(target))) {
+        this.onClose();
+        this.hide();
+      }
+    },
+    hideOnEsc: ({ key }: KeyboardEvent) => {
+      if (key === 'Escape') {
+        this.onClose();
+        this.hide();
+      }
+    },
+    manageFocus: ({ target }: Event) => {
+      if (target === topFocusTrap) {
+        lastFocusableElement.focus();
+      } else if (target === bottomFocusTrap) {
+        firstFocusableElement.focus();
+      }
+    },
+  };
+
+  constructor(onClose: () => void) {
+    this.onClose = onClose;
+  }
+
+  show() {
+    toolbar.setAttribute('inert', 'true');
+    overlay.classList.add('visible');
+    firstFocusableElement.focus();
+
+    topFocusTrap.addEventListener('focus', this.listeners.manageFocus);
+    bottomFocusTrap.addEventListener('focus', this.listeners.manageFocus);
+    window.addEventListener('keydown', this.listeners.hideOnEsc);
+    overlay.addEventListener('click', this.listeners.hideOnClick);
+    btnClose.addEventListener('click', this.listeners.hideOnClick);
+  }
+
+  hide() {
+    toolbar.removeAttribute('inert');
+    overlay.classList.add('hiding');
+
+    overlay.addEventListener(
+      'animationend',
+      () => {
+        overlay.classList.remove('visible', 'hiding');
+
+        // Restore focus to the button that opened the info dialog
+        btnInfo.focus();
+      },
+      { once: true },
+    );
+
+    topFocusTrap.removeEventListener('focus', this.listeners.manageFocus);
+    bottomFocusTrap.removeEventListener('focus', this.listeners.manageFocus);
+    window.removeEventListener('keydown', this.listeners.hideOnEsc);
+    overlay.removeEventListener('click', this.listeners.hideOnClick);
+    btnClose.removeEventListener('click', this.listeners.hideOnClick);
+  }
+}


### PR DESCRIPTION
### Cambios
- Se mueven los listeners del `ConfirmDialog` fuera del constructor
- Se espera a que el `ConfirmDialog` termine de ocultarse antes de devolver focus al botón que lo abrió
- Se lleva la lógica del modal de información a su propio archivo, siguiendo el mismo comportamiento que en el `ConfirmDialog`