### PR TITLE
Attach event listeners to body & stop drawing on mouse leave

### DIFF
--- a/scripts/canvas.ts
+++ b/scripts/canvas.ts
@@ -57,7 +57,7 @@ export class Canvas {
 
     this.fill(this.backgroundColor);
 
-    window.addEventListener('mousemove', ({ x, y }) => {
+    document.body.addEventListener('mousemove', ({ x, y }) => {
       const coords: Coordinate = { x, y };
 
       if (this.drawingMode === 'rainbow-brush') {
@@ -67,11 +67,11 @@ export class Canvas {
       this.currentCoords = coords;
     });
 
-    window.addEventListener('touchstart', () => {
+    document.body.addEventListener('touchstart', () => {
       this.currentCoords = null;
     });
 
-    window.addEventListener(
+    document.body.addEventListener(
       'touchmove',
       (ev) => {
         if (ev.target === this.canvas) {

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -29,6 +29,7 @@ const allButtonsInsideToolbar = toolbar.querySelectorAll<HTMLElement>('button, a
 const notificationsContainer = new NotificationContainer($('#notifications-container'));
 
 let isDialogOpen = false;
+let isDrawing = false;
 const collapseButtonHeight = `${btnCollapseToolbar.scrollHeight}px`;
 const toolbarHeight = `${toolbar.scrollHeight}px`;
 toolbar.style.height = toolbarHeight;
@@ -50,6 +51,7 @@ const undoAndSetCanvasColor = () => {
 };
 
 const stopDrawing = () => {
+  isDrawing = false;
   canvas.stopDrawing();
 
   toolbar.classList.remove('is-drawing');
@@ -65,6 +67,7 @@ const fillCanvasOrBeginDrawing = (ev: CanvasEvent) => {
   if (current === btnRoller) {
     canvas.fill();
   } else {
+    isDrawing = true;
     toolbar.classList.add('is-drawing');
 
     // To prevent pressing tab and changing tools while drawing
@@ -263,4 +266,10 @@ window.addEventListener('keydown', (ev) => {
 window.addEventListener('mousemove', ({ x, y }) => {
   pointer.style.top = y + 'px';
   pointer.style.left = x + 'px';
+});
+
+document.body.addEventListener('mouseleave', () => {
+  if (isDrawing) {
+    stopDrawing();
+  }
 });


### PR DESCRIPTION
### Cambios
Para resolver un bug producido cuando el usuario está dibujando, mueve el mouse fuera de la ventana y suelta el click, se llama a `stopDrawing` en el evento `mouseleave`.

Además, con el fin de tener mejor uso de la memoria, se le ponen ciertos Event Listeners del Canvas al Body en lugar de a Window.