### PR TITLE
Update icons stroke width

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,18 +33,7 @@
         id="btn-collapse"
         class="btn btn-collapse"
       >
-        <svg
-          aria-hidden="true"
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor">
           <path stroke="none" d="M0 0h24v24H0z" fill="none" />
           <path d="M7 11l5 -5l5 5" />
           <path d="M7 17l5 -5l5 5" />
@@ -53,16 +42,7 @@
 
       <div aria-expanded="true" class="tools-container" id="tools-container">
         <button id="btn-brush" class="btn btn-brush">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M3 21v-4a4 4 0 1 1 4 4h-4"></path>
             <path d="M21 3a16 16 0 0 0 -12.8 10.2"></path>
             <path d="M21 3a16 16 0 0 1 -10.2 12.8"></path>
@@ -73,16 +53,7 @@
         </button>
 
         <button id="btn-eraser" class="btn btn-eraser">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path
               d="M19 20h-10.5l-4.21 -4.3a1 1 0 0 1 0 -1.41l10 -10a1 1 0 0 1 1.41 0l5 5a1 1 0 0 1 0 1.41l-9.2 9.3"
             ></path>
@@ -93,16 +64,7 @@
         </button>
 
         <button id="btn-rainbow" class="btn btn-rainbow">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M22 17c0 -5.523 -4.477 -10 -10 -10s-10 4.477 -10 10"></path>
             <path d="M18 17a6 6 0 1 0 -12 0"></path>
             <path d="M14 17a2 2 0 1 0 -4 0"></path>
@@ -112,16 +74,7 @@
         </button>
 
         <button id="btn-roller" class="btn btn-roller">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
             <path d="M5 3m0 2a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2z" />
             <path d="M19 6h1a2 2 0 0 1 2 2a5 5 0 0 1 -5 5l-5 0v2" />
@@ -132,16 +85,7 @@
         </button>
 
         <button id="btn-undo" class="btn">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
             <path d="M9 11l-4 4l4 4m-4 -4h11a4 4 0 0 0 0 -8h-1"></path>
           </svg>
@@ -151,16 +95,7 @@
         <span aria-hidden="true" class="divider"></span>
 
         <button id="btn-random" class="btn btn-random">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path
               d="M18.064 10.877l-4.89 -7.26c-.42 -.625 -1.287 -.803 -1.936 -.397a1.376 1.376 0 0 0 -.41 .397l-4.893 7.26c-1.695 2.838 -1.035 6.441 1.567 8.546c2.203 1.782 5.259 2.056 7.723 .82"
             ></path>
@@ -173,16 +108,7 @@
 
         <div class="input-container btn">
           <input id="btn-color" class="input-color" type="color" autocomplete="off" />
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path
               d="M12 21a9 9 0 0 1 0 -18c4.97 0 9 3.582 9 8c0 1.06 -.474 2.078 -1.318 2.828c-.844 .75 -1.989 1.172 -3.182 1.172h-2.5a2 2 0 0 0 -1 3.75a1.3 1.3 0 0 1 -1 2.25"
             ></path>
@@ -213,16 +139,7 @@
         <span aria-hidden="true" class="divider"></span>
 
         <button id="btn-clear" class="btn btn-clear">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
             <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
           </svg>
@@ -231,16 +148,7 @@
         </button>
 
         <a href="#" id="btn-download" target="_blank" download="mi-dibujo.png" class="btn btn-download">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
             <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
             <path d="M12 17v-6"></path>
@@ -251,16 +159,7 @@
         </a>
 
         <button id="btn-info" class="btn btn-info">
-          <svg
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"></path>
             <path d="M12 9h.01"></path>
             <path d="M11 12h1v4h1"></path>
@@ -278,15 +177,7 @@
         <span tabindex="0" id="modal-focus-trap-top"></span>
 
         <button aria-label="Cerrar" role="button" class="btn btn-close" id="btn-close">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
+          <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M18 6l-12 12"></path>
             <path d="M6 6l12 12"></path>
           </svg>
@@ -313,16 +204,7 @@
               rel="noopener noreferrer"
               class="btn"
             >
-              <svg
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                stroke-width="2"
-                stroke="currentColor"
-                fill="none"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
+              <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
                 <path
                   d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z"
                 ></path>
@@ -336,16 +218,7 @@
           </li>
           <li>
             <a href="https://github.com/Aglowkeys/" target="_blank" rel="noopener noreferrer" class="btn">
-              <svg
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                stroke-width="2"
-                stroke="currentColor"
-                fill="none"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
+              <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
                 <path
                   d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5"
                 ></path>
@@ -360,16 +233,7 @@
               rel="noopener noreferrer"
               class="btn"
             >
-              <svg
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                stroke-width="2"
-                stroke="currentColor"
-                fill="none"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
+              <svg aria-hidden="true" viewBox="0 0 24 24" stroke="currentColor" fill="none">
                 <path
                   d="M3 7m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v9a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"
                 ></path>
@@ -399,7 +263,7 @@
     <div id="notifications-container" class="notifications-container">
       <template id="notification-template">
         <div role="alert" class="notification">
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
             <path
               d="M17 3.34a10 10 0 1 1 -14.995 8.984l-.005 -.324l.005 -.324a10 10 0 0 1 14.995 -8.336zm-1.293 5.953a1 1 0 0 0 -1.32 -.083l-.094 .083l-3.293 3.292l-1.293 -1.292l-.094 -.083a1 1 0 0 0 -1.403 1.403l.083 .094l2 2l.094 .083a1 1 0 0 0 1.226 0l.094 -.083l4 -4l.083 -.094a1 1 0 0 0 -.083 -1.32z"

--- a/styles.css
+++ b/styles.css
@@ -13,8 +13,8 @@
 :root {
   --pointer-bg-color: #000;
 
-  --gray-50: #f9f9f9;
-  --gray-100: #fafafa;
+  --gray-50: #fcfcfc;
+  --gray-100: #f9f9f9;
   --gray-200: #e5e4e6;
   --gray-300: #c5c4c7;
   --gray-400: #a2a1a5;
@@ -36,18 +36,18 @@
   --font-size-m: 1.25rem;
   --font-size-l: 1.5rem;
 
-  --font-weight-regular: 500;
-  --font-weight-bold: 600;
-  --font-weight-black: 700;
+  --font-weight-thin: 400;
+  --font-weight-regular: 450;
 
   --dialog-box-shadow: 0 0.5em 1em -0.5em rgba(0, 0, 0, 0.3);
   --notification-box-shadow: 0 0.4em 0.5em -0.5em rgba(0, 0, 0, 0.45);
+  --stroke-size: 1.5px;
 }
 
 body {
   font-family: 'Geist', 'Helvetica', 'Arial', sans-serif;
   font-size: var(--font-size-s);
-  font-weight: var(--font-weight-regular);
+  font-weight: var(--font-weight-thin);
   letter-spacing: -0.04em;
 }
 
@@ -66,6 +66,9 @@ canvas {
 svg {
   width: 1.25rem;
   height: 1.25rem;
+  stroke-width: var(--stroke-size);
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .toolbar {
@@ -127,8 +130,7 @@ svg {
   bottom: 0.1rem;
   right: 0.15rem;
   font-size: var(--font-size-xxs);
-  font-weight: var(--font-weight-black);
-  color: var(--primary-300);
+  color: var(--primary-400);
 }
 
 .btn {
@@ -262,7 +264,7 @@ svg {
 
 .input-range {
   appearance: none;
-  height: 2px;
+  height: var(--stroke-size);
   border-radius: 9em;
   background: var(--gray-800);
   max-width: 5em;
@@ -543,7 +545,7 @@ svg {
 
 .card h2 {
   line-height: 1;
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-regular);
   font-size: var(--font-size-m);
   margin-bottom: 0.25em;
 }
@@ -594,7 +596,7 @@ svg {
 .confirm__button {
   font: inherit;
   border: none;
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 0.9rem;
   border-radius: 0.3rem;
   cursor: pointer;
   outline: 2px solid transparent;


### PR DESCRIPTION
### Cambios
- Se quitan atributos innecesarios en SVG para mayor limpieza en el HTML
- Se estilan los SVG en el CSS en lugar de usando los atributos
- Se cambia la fuente por pesos más ligeros y se les da a los SVG un stroke de 1.5px en lugar de 2px

| Antes | Después |
|--------|--------|
| ![imagen](https://github.com/user-attachments/assets/dfe8fb94-94b5-4961-a0c6-0bd7d8b835e2) | ![imagen](https://github.com/user-attachments/assets/3922073d-00c2-4d4c-9bb7-534f97084238) |
| ![imagen](https://github.com/user-attachments/assets/b8cfc1ef-f91f-4ee6-85c0-81e674bce29c)| ![imagen](https://github.com/user-attachments/assets/77a20a92-b9a9-460a-ae74-ddc7d24105de)|
| ![imagen](https://github.com/user-attachments/assets/45eb8d0a-df42-4f9c-88ed-21f4215abdd4) | ![imagen](https://github.com/user-attachments/assets/2cabaef6-c399-4aac-b8e9-ff68469fcfc5) | 