### PR TITLE
Change aria-label to aria-labelledby to improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <aside id="toolbar" class="toolbar">
       <button
         aria-controls="tools-container"
-        aria-label="Contraer barra de herramientas"
+        aria-labelledby="toolbar-collapse-label"
         id="btn-collapse"
         class="btn btn-collapse"
       >
@@ -38,6 +38,8 @@
           <path d="M7 11l5 -5l5 5" />
           <path d="M7 17l5 -5l5 5" />
         </svg>
+
+        <span id="toolbar-collapse-label" hidden>Contraer barra de herramientas</span>
       </button>
 
       <div aria-expanded="true" class="tools-container" id="tools-container">
@@ -176,11 +178,12 @@
       <div class="card modal" id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
         <span tabindex="0" id="modal-focus-trap-top"></span>
 
-        <button aria-label="Cerrar" role="button" class="btn btn-close" id="btn-close">
+        <button aria-labelledby="modal-close-btn-label" role="button" class="btn btn-close" id="btn-close">
           <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
             <path d="M18 6l-12 12"></path>
             <path d="M6 6l12 12"></path>
           </svg>
+          <span id="modal-close-btn-label" hidden>Cerrar</span>
         </button>
 
         <h2 id="modal-title">Sobre este proyecto</h2>

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -14,6 +14,7 @@ const pointer = $('#pointer');
 const toolbar = $('#toolbar');
 const toolsContainer = $('#tools-container');
 const btnCollapseToolbar = $('#btn-collapse');
+const btnCollapseLabel = $('#toolbar-collapse-label');
 const btnBrush = $('#btn-brush');
 const btnEraser = $('#btn-eraser');
 const btnRainbow = $('#btn-rainbow');
@@ -95,10 +96,7 @@ btnCollapseToolbar.addEventListener('click', () => {
   const isCollapsed = toolbar.classList.toggle('toolbar--collapsed');
   toolbar.style.height = isCollapsed ? collapseButtonHeight : toolbarHeight;
 
-  btnCollapseToolbar.setAttribute(
-    'aria-label',
-    `${isCollapsed ? 'Expandir' : 'Contraer'} barra de herramientas`,
-  );
+  btnCollapseLabel.textContent = `${isCollapsed ? 'Expandir' : 'Contraer'} barra de herramientas`;
   toolsContainer.setAttribute('aria-expanded', `${!isCollapsed}`);
   toolbar.style.overflow = 'hidden';
   toolsContainer.style.visibility = 'visible';


### PR DESCRIPTION
### Cambios
Dado que `aria-label` [podría no traducirse correctamente](https://adrianroselli.com/2019/11/aria-label-does-not-translate.html), se cambia por un `aria-labelledby` con un spancon el atributo `hidden`.